### PR TITLE
Replace Linker::makeKnownLinkObj with linkKnown to fix MW 1.27 compatibility

### DIFF
--- a/AudioPlayer2.body.php
+++ b/AudioPlayer2.body.php
@@ -54,7 +54,7 @@ class AudioPlayer2 {
 
 		if (!in_array($mimetype, self::$handled_mimetypes)) {
 			// Display as page link if not applicable.
-			return Linker::makeKnownLinkObj($title);
+			return Linker::linkKnown($title);
 		}
 
 		$id = self::makeUniqueId();
@@ -71,7 +71,7 @@ class AudioPlayer2 {
 
 		self::addFile($image, $id, $file_title, $file_author);
 
-		return '<div id="'.$id.'">' . Linker::makeKnownLinkObj($title) . '</div>';
+		return '<div id="'.$id.'">' . Linker::linkKnown($title) . '</div>';
 	}
 	
 	/** Set the tags to handle (default: "player")


### PR DESCRIPTION
This is necessary for the plugin to work with MediaWiki 1.27.

Apparently, Linker::makeKnownLinkObj was deprecated some time ago and now removed, so that the plugin broke my MediaWiki installation.

It would be great if this change is made public, so that the plugin is compatible with the latest MediaWiki version. :)
